### PR TITLE
Utility for printing DMAR table

### DIFF
--- a/dmardump/Makefile
+++ b/dmardump/Makefile
@@ -1,0 +1,14 @@
+PROG=	dmardump
+SRCS=	dmardump.c acpi_decode.c utils.c
+
+CFLAGS+= -Wall -O2 -D_LINUX -Wstrict-prototypes
+
+all: $(PROG)
+
+$(PROG) : $(SRCS)
+	$(CC) $(CFLAGS) $(SRCS) -o $(PROG)
+
+CLEANFILES= $(PROG)
+
+clean:
+	rm -f $(CLEANFILES) $(patsubst %.c,%.o, $(SRCS))

--- a/dmardump/acpi_decode.c
+++ b/dmardump/acpi_decode.c
@@ -1,0 +1,360 @@
+/*
+ * acpi_decode.c: Routines to decode ACPI static tables.
+ *
+ * Copyright (c) 2020, Ross Philipson ross.philipson@gmail.com
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include "defs.h"
+
+#define ACPI_ERROR "ACPI-DECODE-ERROR"
+#define ACPI_WARN "ACPI-DECODE-WARN"
+
+#define SCAN_ROM_BIOS_BASE 0xE0000
+#define SCAN_ROM_BIOS_SIZE 0x20000
+
+/* Lengths */
+#define ACPI_RSDP_LENGTH      0x24
+#define ACPI_RSDP_CS_LENGTH   0x14
+#define ACPI_RSDP_XCS_LENGTH  0x24
+#define ACPI_HEADER_LENGTH    0x24
+
+/* Offsets */
+#define ACPI_RSDP_SIGNATURE	0x00 /* 8 BYTES ASCII "RSD PTR " anchor string */
+#define ACPI_RSDP_CHECKSUM	0x08 /* BYTE ACPI 1.0 CS sums to zero when added to bytes in RSDP */
+#define ACPI_RSDP_OEM_ID 	0x09 /* 6 BYTES ASCII OEM ID */
+#define ACPI_RSDP_REVISION	0x0F /* BYTE 0 for ACPI 1.0 or 2 for ACPI 2.0 */
+#define ACPI_RSDP_RSDT_BASE	0x10 /* 4 BYTES 32b physical base address of the RSDT */
+#define ACPI_RSDP_XSDT_LENGTH	0x14 /* 4 BYTES length of XSDT */
+#define ACPI_RSDP_XSDT_BASE	0x18 /* 8 BYTES 64b physical base address of the XSDT */
+#define ACPI_RSDP_EXT_CHECKSUM	0x20 /* BYTE ACPI 2.0 CS sums to zero when added to bytes in RSDP */
+#define ACPI_RSDP_RESERVED	0x21 /* 3 BYTES align table */
+
+#define ACPI_TABLE_SIGNATURE	0x00 /* 4 BYTES signature string */
+#define ACPI_TABLE_LENGTH	0x04 /* 4 BYTES length of the table in bytes including header */
+#define ACPI_TABLE_REVISION	0x08 /* BYTE minor rev number */
+#define ACPI_TABLE_CHECKSUM	0x09 /* BYTE sums to zero when added to bytes in table */
+#define ACPI_TABLE_OEM_ID	0x0A /* 6 BYTES ASCII OEM ID */
+#define ACPI_TABLE_OEM_TABLE_ID	0x10 /* 8 BYTES ASCII OEM TABLE ID */
+#define ACPI_TABLE_OEM_REVISION	0x18 /* 4 BYTES OEM rev number */
+#define ACPI_TABLE_CREATOR_ID	0x1C /* 4 BYTES ASCII CREATOR ID */
+#define ACPI_TABLE_CREATOR_REVISION 0x20 /* 4 BYTES CREATOR REVISION */
+
+struct acpi_rsdp_info {
+	size_t rsdt_phys_addr;
+	size_t xsdt_phys_addr;
+	uint8_t *rsdt_addr;
+	uint32_t rsdt_length;
+	uint8_t *xsdt_addr;
+	uint32_t xsdt_length;
+	uint32_t is_rev1;
+};
+
+struct acpi_table_info {
+	size_t phys_addr;
+	uint8_t *addr;
+	uint32_t length;
+};
+
+static int process_acpi_rsdp(struct acpi_rsdp_info *rsdpinfo, uint8_t *rsdp)
+{
+#define ADDR_CHECK(a, p) if (a == NULL) { \
+	printf("%s: failed to map ACPI table at phys="UINT_FMT"\n", ACPI_ERROR, p); \
+	rc = -1; break;}
+	uint8_t cs;
+	uint32_t count, length;
+	uint8_t *addr;
+	int rc = 0;
+
+	do {
+		/* checksum sanity check over the RSDP */
+		if (rsdp[ACPI_RSDP_REVISION] < 2) {
+			length = ACPI_RSDP_CS_LENGTH;
+			rsdpinfo->is_rev1 = 1;
+		}
+		else
+			length = ACPI_RSDP_XCS_LENGTH;
+
+		for (cs = 0, count = 0; count < length; count++)
+			cs += rsdp[count];
+		if (cs != 0) {
+			printf("%s: invalid RSDP checksum\n", ACPI_ERROR);
+			rc = -1;
+			break;
+		}
+
+		/* looks like the RSDP, get RSDP table */
+		rsdpinfo->rsdt_phys_addr = (*(uint32_t*)(rsdp + ACPI_RSDP_RSDT_BASE));
+		rsdpinfo->rsdt_length = ACPI_HEADER_LENGTH;
+		addr = helper_mmap(rsdpinfo->rsdt_phys_addr, ACPI_HEADER_LENGTH);
+		ADDR_CHECK(addr, rsdpinfo->rsdt_phys_addr);
+
+		rsdpinfo->rsdt_addr = addr;
+		/* check the signatures for the RSDT */
+		if (memcmp(rsdpinfo->rsdt_addr, "RSDT", 4) != 0) {
+			printf("%s: invalid RSDT signature=%.*s\n",
+				ACPI_ERROR, 4, rsdpinfo->rsdt_addr);
+			rc = -1;
+			break;
+		}
+
+		/* remap the entire table */
+		rsdpinfo->rsdt_length = (*(uint32_t*)(rsdpinfo->rsdt_addr + ACPI_TABLE_LENGTH));
+		helper_unmmap(rsdpinfo->rsdt_addr, ACPI_HEADER_LENGTH);
+		rsdpinfo->rsdt_addr = NULL;
+		addr = helper_mmap(rsdpinfo->rsdt_phys_addr, rsdpinfo->rsdt_length);
+		ADDR_CHECK(addr, rsdpinfo->rsdt_phys_addr);
+		rsdpinfo->rsdt_addr = addr;
+
+		if (rsdpinfo->is_rev1)
+			break;
+
+		/* Also have an XSDT */
+		rsdpinfo->xsdt_phys_addr = (*(uint64_t*)(rsdp + ACPI_RSDP_XSDT_BASE));
+		rsdpinfo->xsdt_length = ACPI_HEADER_LENGTH;
+		addr = helper_mmap(rsdpinfo->xsdt_phys_addr, ACPI_HEADER_LENGTH);
+		ADDR_CHECK(addr, rsdpinfo->xsdt_phys_addr);
+		rsdpinfo->xsdt_addr = addr;
+
+		/* check the signatures for the XSDT */
+		if (memcmp(rsdpinfo->xsdt_addr, "XSDT", 4) != 0) {
+			printf("%s: invalid XSDT signature=%.*s\n",
+				ACPI_ERROR, 4, rsdpinfo->xsdt_addr);
+			rc = -1;
+			break;
+		}
+
+		/* remap the entire table */
+		rsdpinfo->xsdt_length = (*(uint32_t*)(rsdpinfo->xsdt_addr + ACPI_TABLE_LENGTH));
+		helper_unmmap(rsdpinfo->xsdt_addr, ACPI_HEADER_LENGTH);
+		rsdpinfo->xsdt_addr = NULL;
+		addr = helper_mmap(rsdpinfo->xsdt_phys_addr, rsdpinfo->xsdt_length);
+		ADDR_CHECK(addr, rsdpinfo->xsdt_phys_addr);
+		rsdpinfo->xsdt_addr = addr;
+	} while (0);
+#undef ADDR_CHECK
+
+	if (rc != 0) {
+		if (rsdpinfo->rsdt_addr != NULL)
+			helper_unmmap(rsdpinfo->rsdt_addr, rsdpinfo->rsdt_length);
+		if (rsdpinfo->xsdt_addr != NULL)
+		helper_unmmap(rsdpinfo->xsdt_addr, rsdpinfo->xsdt_length);
+	}
+
+	return rc;
+}
+
+static int locate_acpi_pointers(struct acpi_rsdp_info *rsdpinfo)
+{
+	size_t loc = 0;
+	uint8_t *addr;
+	int rc = -1; /* in case we don't find it */
+
+	memset(rsdpinfo, 0, sizeof(struct acpi_rsdp_info));
+
+	/* use EFI tables if present */
+	rc = helper_efi_locate("ACPI20", 6, &loc);
+	if ( (rc == 0) && (loc != 0) ) {
+		addr = helper_mmap(loc, ACPI_RSDP_LENGTH);
+		if (addr == NULL) {
+			printf("%s: failed to map EFI RSDP at phys="UINT_FMT"\n",
+				ACPI_ERROR, loc);
+			return -1;
+		}
+		rc = process_acpi_rsdp(rsdpinfo, addr);
+		helper_unmmap(addr, ACPI_RSDP_LENGTH);
+		return rc;
+	}
+
+	/* locate ACPI entry via memory scan of ROM region */
+	addr = helper_mmap(SCAN_ROM_BIOS_BASE, SCAN_ROM_BIOS_SIZE);
+	if (addr == NULL) {
+		printf("%s: failed to map ROM BIOS at phys=%x\n",
+			ACPI_ERROR, SCAN_ROM_BIOS_BASE);
+		return -1;
+	}
+
+	for (loc = 0; loc <= (SCAN_ROM_BIOS_SIZE - ACPI_RSDP_LENGTH); loc += 16) { /* stop before 0xFFDC */
+		/* look for RSD PTR  signature */
+		if (memcmp(addr + loc, "RSD PTR ", 8) == 0) {
+			rc = process_acpi_rsdp(rsdpinfo, addr + loc);
+			if (rc == 0) /* found it */
+				break;
+		}
+	}
+	helper_unmmap(addr, SCAN_ROM_BIOS_SIZE);
+
+	return rc;
+}
+
+static int locate_rsdt_acpi_table(struct acpi_rsdp_info *rsdpinfo,
+		const char *signature, struct acpi_table_info *ti)
+{
+	uint32_t *addr_list;
+	uint32_t length, count, i;
+	int rc = -1;
+	uint8_t *addr;
+
+	if (rsdpinfo->rsdt_length <= ACPI_TABLE_LENGTH) {
+		printf("%s: invalid RSDT - no table pointers\n", ACPI_ERROR);
+		return -1; /* invalid - no tables?? */
+	}
+
+	length = rsdpinfo->rsdt_length - ACPI_HEADER_LENGTH;
+	count = length/sizeof(uint32_t);
+	addr_list = (uint32_t*)(rsdpinfo->rsdt_addr + ACPI_HEADER_LENGTH);
+
+	for (i = 0; i < count; i++, addr_list++) {
+		addr = helper_mmap(*addr_list, ACPI_HEADER_LENGTH);
+		if (addr == NULL)
+			continue;
+
+		if (memcmp(addr, signature, 4) == 0) {
+			ti->length = (*(uint32_t*)(addr + ACPI_TABLE_LENGTH));
+			helper_unmmap(addr, ACPI_HEADER_LENGTH);
+			addr = helper_mmap(*addr_list, ti->length);
+			if (addr == NULL) {
+				printf("%s: failed to map table #%d at phys=%x\n",
+					ACPI_ERROR, i, *addr_list);
+				break;
+			}
+			ti->phys_addr = *addr_list;
+			ti->addr = addr;
+			rc = 0;
+			break;
+		}
+
+		helper_unmmap(addr, ACPI_HEADER_LENGTH);
+	}
+
+	return rc;
+}
+
+static int locate_xsdt_acpi_table(struct acpi_rsdp_info *rsdpinfo, const char *signature, struct acpi_table_info *ti)
+{
+	uint64_t *addr_list;
+	uint32_t length, count, i;
+	int rc = -1;
+	uint8_t *addr;
+
+	if (rsdpinfo->xsdt_length <= ACPI_TABLE_LENGTH) {
+		printf("%s: invalid XSDT - no table pointers\n", ACPI_ERROR);
+		return -1; /* invalid - no tables?? */
+	}
+
+	length = rsdpinfo->xsdt_length - ACPI_HEADER_LENGTH;
+	count = length/sizeof(uint64_t);
+	addr_list = (uint64_t*)(rsdpinfo->xsdt_addr + ACPI_HEADER_LENGTH);
+
+	for (i = 0; i < count; i++, addr_list++) {
+		addr = helper_mmap(*addr_list, ACPI_HEADER_LENGTH);
+		if (addr == NULL)
+			continue;
+
+		if (memcmp(addr, signature, 4) == 0) {
+			ti->length = (*(uint32_t*)(addr + ACPI_TABLE_LENGTH));
+			helper_unmmap(addr, ACPI_HEADER_LENGTH);
+			addr = helper_mmap(*addr_list, ti->length);
+			if (addr == NULL) {
+				printf("%s: failed to map table #%d at phys=%lx\n",
+					ACPI_ERROR, i, (long unsigned int)*addr_list);
+				break;
+			}
+			ti->phys_addr = *addr_list;
+			ti->addr = addr;
+			rc = 0;
+			break;
+		}
+
+		helper_unmmap(addr, ACPI_HEADER_LENGTH);
+	}
+
+	return rc;
+}
+
+static int decode_acpi_tables(struct acpi_rsdp_info *rsdpinfo, uint8_t *dmar_buf, uint32_t length)
+{
+	int rc = 0;
+	struct acpi_table_info ti = {0};
+
+	/* locate the DMAR - use XSDT if present */
+	if (!rsdpinfo->is_rev1)
+		rc = locate_xsdt_acpi_table(rsdpinfo, ACPI_SIG_DMAR, &ti);
+	else
+		rc = locate_rsdt_acpi_table(rsdpinfo, ACPI_SIG_DMAR, &ti);
+
+	if (rc != 0) {
+		printf("%s: failed to locate %s table\n", ACPI_ERROR, ACPI_SIG_DMAR);
+		return rc;
+	}
+
+	if (ti.length <= length) {
+		/* If we got it, copy it over */
+		memcpy(dmar_buf, ti.addr, ti.length);
+	} else {
+		printf("%s: cannot copy %s table length=%x - out of space\n",
+			ACPI_ERROR, ACPI_SIG_DMAR, ti.length);
+		rc = -1;
+	}
+
+	helper_unmmap(ti.addr, ti.length);
+	return rc;
+}
+
+int acpi_get_dmar(uint8_t *dmar_buf, uint32_t length)
+{
+	struct acpi_rsdp_info rsdpinfo;
+	int rc;
+
+	/* first locate the ACPI  tables */
+	rc = locate_acpi_pointers(&rsdpinfo);
+	if (rc != 0) {
+		printf("%s: failed to find ACPI info\n", ACPI_ERROR);
+		return rc;
+	}
+
+	/* process the ACPI tables */
+	rc = decode_acpi_tables(&rsdpinfo, dmar_buf, length);
+
+	/* cleanup */
+	helper_unmmap(rsdpinfo.rsdt_addr, rsdpinfo.rsdt_length);
+	if (!rsdpinfo.is_rev1)
+		helper_unmmap(rsdpinfo.xsdt_addr, rsdpinfo.xsdt_length);
+
+	if (rc != 0)
+		printf("%s: decoding failed\n", ACPI_ERROR);
+
+	return rc;
+}

--- a/dmardump/defs.h
+++ b/dmardump/defs.h
@@ -1,0 +1,53 @@
+/*
+ * acpi_decode.c: Definitions for dmardump utility.
+ *
+ * Copyright (c) 2020, Ross Philipson ross.philipson@gmail.com
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __DEFS_H__
+#define __DEFS_H__
+
+#if __WORDSIZE == 64
+#define INT_FMT "%ld"
+#define UINT_FMT "%lx"
+#else
+#define INT_FMT "%d"
+#define UINT_FMT "%x"
+#endif
+
+#define ACPI_SIG_DMAR	"DMAR"	/* DMA Remapping table */
+
+uint8_t *helper_mmap(size_t phys_addr, size_t length);
+void helper_unmmap(uint8_t *addr, size_t length);
+int helper_efi_locate(const char *efi_entry, uint32_t length, size_t *location);
+
+int acpi_get_dmar(uint8_t *dmar_buf, uint32_t length);
+
+#endif /* __DEFS_H__ */

--- a/dmardump/dmardump.c
+++ b/dmardump/dmardump.c
@@ -1,0 +1,469 @@
+/*
+ * acpi_decode.c: Routines to scan and print DMAR table.
+ *
+ * Copyright (c) 2020, Ross Philipson ross.philipson@gmail.com
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "defs.h"
+
+#define ACPI_NAME_SIZE		4
+#define ACPI_OEM_ID_SIZE	6
+#define ACPI_OEM_TABLE_ID_SIZE	8
+
+#define BITS_PER_LONG		32
+#define BITS_TO_LONGS(bits) \
+	(((bits)+BITS_PER_LONG-1)/BITS_PER_LONG)
+#define DECLARE_BITMAP(name,bits) \
+	unsigned long name[BITS_TO_LONGS(bits)]
+
+#define MIN_SCOPE_LEN (sizeof(struct acpi_pci_path) + \
+	sizeof(struct acpi_dev_scope))
+
+#define DMAR_MAX_BUF		4096 /* should be enough room for any DMAR */
+
+#define DRHD_FLAGS_INCLUDE_ALL	0x1       /* drhd remaps remaining devices */
+
+#define DMAR_TYPE	1
+#define RMRR_TYPE	2
+#define ATSR_TYPE	3
+
+enum acpi_dmar_entry_type {
+	ACPI_DMAR_DRHD = 0,
+	ACPI_DMAR_RMRR,
+	ACPI_DMAR_ATSR,
+	ACPI_DMAR_ENTRY_COUNT
+};
+
+/* Values for entry_type in struct acpi_dmar_device_scope */
+
+enum acpi_dmar_scope_type {
+	ACPI_DMAR_SCOPE_TYPE_NOT_USED = 0,
+	ACPI_DMAR_SCOPE_TYPE_ENDPOINT = 1,
+	ACPI_DMAR_SCOPE_TYPE_BRIDGE = 2,
+	ACPI_DMAR_SCOPE_TYPE_IOAPIC = 3,
+	ACPI_DMAR_SCOPE_TYPE_HPET = 4,
+	ACPI_DMAR_SCOPE_TYPE_RESERVED = 5	/* 5 and greater are reserved */
+};
+
+enum acpi_dev_scope_type {
+	ACPI_DEV_ENDPOINT=0x01,	/* PCI Endpoing device */
+	ACPI_DEV_P2PBRIDGE,	/* PCI-PCI Bridge */
+	ACPI_DEV_IOAPIC,	/* IOAPIC device*/
+	ACPI_DEV_MSI_HPET,	/* MSI capable HPET*/
+	ACPI_DEV_ENTRY_COUNT
+};
+
+struct acpi_table_header {
+	char signature[ACPI_NAME_SIZE];	/* ASCII table signature */
+	uint32_t length;		/* Length of table in bytes, including this header */
+	uint8_t revision;		/* ACPI Specification minor version # */
+	uint8_t checksum;		/* To make sum of entire table == 0 */
+	char oem_id[ACPI_OEM_ID_SIZE];	/* ASCII OEM identification */
+	char oem_table_id[ACPI_OEM_TABLE_ID_SIZE];	/* ASCII OEM table identification */
+	uint32_t oem_revision;			/* OEM revision number */
+	char asl_compiler_id[ACPI_NAME_SIZE];	/* ASCII ASL compiler vendor ID */
+	uint32_t asl_compiler_revision;		/* ASL compiler version */
+};
+
+struct acpi_table_dmar {
+	struct acpi_table_header header;	/* Common ACPI table header */
+	uint8_t width;				/* Host Address Width */
+	uint8_t flags;
+	uint8_t reserved[10];
+};
+
+struct acpi_dmar_entry_header {
+	uint16_t type;
+	uint16_t length;
+} __attribute__((packed));
+
+struct dmar_scope {
+	DECLARE_BITMAP(buses, 256);	/* buses owned by this unit */
+	uint16_t *devices;		/* devices owned by this unit */
+	int devices_cnt;
+};
+
+struct acpi_table_drhd {
+	struct	acpi_dmar_entry_header header;
+	uint8_t	flags;
+	uint8_t	reserved;
+	uint16_t segment;
+	uint64_t address; /* register base address for this drhd */
+} __attribute__ ((packed));
+
+struct acpi_table_rmrr {
+	struct acpi_dmar_entry_header header;
+	uint16_t reserved;
+	uint16_t segment;
+	uint64_t base_address;
+	uint64_t end_address;
+} __attribute__ ((packed));
+
+struct acpi_table_atsr {
+	struct acpi_dmar_entry_header header;
+	uint8_t flags;
+	uint8_t reserved;
+	uint16_t segment;
+} __attribute__ ((packed));
+
+struct acpi_dev_scope {
+	uint8_t dev_type;
+	uint8_t length;
+	uint8_t	reserved[2];
+	uint8_t enum_id;
+	uint8_t start_bus;
+} __attribute__((packed));
+
+struct acpi_pci_path {
+	uint8_t dev;
+	uint8_t fn;
+} __attribute__((packed));
+
+static int g_include_all = 0;
+static int g_all_ports = 0;
+
+/*
+ * Count number of devices in device scope.  Do not include PCI sub
+ * hierarchies.
+ */
+static int
+scope_device_count(void *start, void *end)
+{
+	struct acpi_dev_scope *scope;
+	int count = 0;
+
+	while ( start < end ) {
+		scope = start;
+		if (scope->length < MIN_SCOPE_LEN) {
+			printf("*** INVALID device scope - length 0x%2.2x less than minimum 0x%2.2x\n",
+				scope->length, (uint32_t)MIN_SCOPE_LEN);
+			return -1;
+		}
+
+		if (scope->dev_type >= ACPI_DEV_ENTRY_COUNT) {
+			printf("*** INVALID device scope - invalid device type 0x%2.2x\n", scope->dev_type);
+			return -1;
+		}
+
+		if ( scope->dev_type == ACPI_DEV_ENDPOINT ||
+			scope->dev_type == ACPI_DEV_IOAPIC ||
+			scope->dev_type == ACPI_DEV_MSI_HPET )
+			count++;
+
+		start += scope->length;
+	}
+
+	return count;
+}
+
+static void
+acpi_parse_dev_scope(void *start, void *end, int type)
+{
+	struct acpi_dev_scope *acpi_scope;
+	struct acpi_pci_path *path;
+	uint16_t bus;
+	int depth = 0;
+	int i = 1;
+	const char *enumstr = "Reserved";
+
+	if (scope_device_count(start, end) < 0 )
+		return;
+
+	while ( start < end ) {
+		printf("    Device Scope Structure #%d\n", i++);
+		printf("    ==========================\n");
+
+		acpi_scope = start;
+		path = (struct acpi_pci_path *)(acpi_scope + 1);
+		depth = (acpi_scope->length - sizeof(struct acpi_dev_scope))
+			/ sizeof(struct acpi_pci_path);
+		bus = acpi_scope->start_bus;
+
+		switch ( acpi_scope->dev_type ) {
+		case ACPI_DEV_P2PBRIDGE:
+			printf("    Type:           0x%2.2x (ACPI_DEV_P2PBRIDGE)\n", acpi_scope->dev_type);
+			break;
+		case ACPI_DEV_MSI_HPET:
+			printf("    Type:           0x%2.2x (ACPI_DEV_MSI_HPET)\n", acpi_scope->dev_type);
+			break;
+		case ACPI_DEV_ENDPOINT:
+			printf("    Type:           0x%2.2x (ACPI_DEV_ENDPOINT)\n", acpi_scope->dev_type);
+			break;
+		case ACPI_DEV_IOAPIC:
+			printf("    Type:           0x%2.2x (ACPI_DEV_IOAPIC)\n", acpi_scope->dev_type);
+			enumstr = "I/O APICID";
+			break;
+		}
+		printf("    Length:         0x%2.2x\n", acpi_scope->length);
+		printf("    Reserved:       %2.2x %2.2x\n", acpi_scope->reserved[0], acpi_scope->reserved[1]);
+		printf("    Enumeration ID: 0x%2.2x - %s\n", acpi_scope->enum_id, enumstr);
+		printf("    Start Bus Num:  0x%2.2x\n", bus);
+		printf("    Path Depth = %d, Path Entries:\n", depth);
+
+		while ( depth-- > 0 ) {
+			printf("       -- Device: 0x%2.2x Function: 0x%2.2x\n", path->dev, path->fn);
+			path++;
+		}
+
+		start += acpi_scope->length;
+	}
+}
+
+static void
+acpi_parse_one_drhd(struct acpi_dmar_entry_header *header)
+{
+	struct acpi_table_drhd *drhd = (struct acpi_table_drhd *)header;
+	void *dev_scope_start, *dev_scope_end;
+	int include_all = 0;
+
+	include_all = drhd->flags & 1; /* BIT0: INCLUDE_ALL */
+
+	printf("Flags:          0x%2.2x  -- INCLUDE_ALL = %s\n", drhd->flags, (include_all == 1 ? "yes" : "no"));
+	printf("Reserved:       0x%2.2x\n", drhd->reserved);
+	printf("Segment Number: 0x%4.4x\n", drhd->segment);
+	printf("Register Base:  0x%lx\n", drhd->address);
+
+	if (g_include_all != 0) {
+		if (include_all != 0) {
+			printf("*** INVALID DRHD - only one INCLUDE_ALL unit allowed!\n");
+		}
+	} else
+		g_include_all = include_all;
+
+	dev_scope_start = (void *)(drhd + 1);
+	dev_scope_end = ((void *)drhd) + header->length;
+	acpi_parse_dev_scope(dev_scope_start, dev_scope_end, DMAR_TYPE);
+}
+
+static void
+acpi_parse_one_rmrr(struct acpi_dmar_entry_header *header)
+{
+	struct acpi_table_rmrr *rmrr = (struct acpi_table_rmrr *)header;
+	void *dev_scope_start, *dev_scope_end;
+
+	printf("Reserved:       0x%4.4x\n", rmrr->reserved);
+	printf("Segment Number: 0x%4.4x\n", rmrr->segment);
+	printf("Base Address:   0x%lx\n", rmrr->base_address);
+	printf("End Address:    0x%lx\n", rmrr->end_address);
+
+	if ( rmrr->base_address >= rmrr->end_address ) {
+		printf("*** INVALIDE RMRR - base address 0x%lx is greater than the end address 0x%lx\n",
+			rmrr->base_address, rmrr->end_address);
+	}
+
+	dev_scope_start = (void *)(rmrr + 1);
+	dev_scope_end   = ((void *)rmrr) + header->length;
+	acpi_parse_dev_scope(dev_scope_start, dev_scope_end, RMRR_TYPE);
+}
+
+static void
+acpi_parse_one_atsr(struct acpi_dmar_entry_header *header)
+{
+	struct acpi_table_atsr *atsr = (struct acpi_table_atsr *)header;
+	int all_ports;
+	void *dev_scope_start, *dev_scope_end;
+
+	all_ports = atsr->flags & 1; /* BIT0: ALL_PORTS */
+
+	printf("Flags:          0x%2.2x  -- ALL_PORTS = %s\n", atsr->flags, (all_ports == 1 ? "yes" : "no"));
+	printf("Reserved:       0x%2.2x\n", atsr->reserved);
+	printf("Segment Number: 0x%4.4x\n", atsr->segment);
+
+	if ( !all_ports ) {
+		dev_scope_start = (void *)(atsr + 1);
+		dev_scope_end   = ((void *)atsr) + header->length;
+		acpi_parse_dev_scope(dev_scope_start, dev_scope_end, ATSR_TYPE);
+	}
+
+	if (g_all_ports != 0) {
+		if (all_ports != 0)
+			printf("*** INVALID ATSR - only one ALL_PORTS structure allowed!\n");
+	} else
+		g_all_ports = all_ports;
+}
+
+static void
+acpi_parse_dmar(struct acpi_table_header *table)
+{
+	struct acpi_table_dmar *dmar;
+	struct acpi_dmar_entry_header *entry_header;
+	int i = 1, j = 1, k = 1, l = 1;
+	uint8_t *p;
+
+	dmar = (struct acpi_table_dmar *)table;
+
+	printf("DMA Remapping Reporting Structure\n");
+	printf("==================================================\n");
+	printf("Signature:        %.4s\n", dmar->header.signature);
+	printf("Length:           0x%8.8x\n", dmar->header.length);
+	printf("Revision:         0x%2.2x\n", dmar->header.revision);
+	printf("Checksum:         0x%2.2x\n", dmar->header.checksum);
+	printf("OEMID:            %.*s\n", ACPI_OEM_ID_SIZE, dmar->header.oem_id);
+	printf("OEM Table ID:     %.*s\n", ACPI_OEM_TABLE_ID_SIZE, dmar->header.oem_table_id);
+	printf("OEM Revision:     0x%8.8x\n", dmar->header.oem_revision);
+	printf("Creator ID:       %.*s\n", ACPI_NAME_SIZE, dmar->header.asl_compiler_id);
+	printf("Creator Revision: 0x%8.8x\n", dmar->header.asl_compiler_revision);
+	printf("HAW:              0x%2.2x\n", dmar->width);
+	printf("Flags:            0x%2.2x\n", dmar->flags);
+
+	p = &dmar->reserved[0];
+	printf("Reserved[10]: %2.2x %2.2x %2.2x %2.2x %2.2x %2.2x %2.2x %2.2x %2.2x %2.2x\n",
+	  p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9]);
+
+	if (!dmar->width)
+		printf("*** Invalid DMAR width of zero\n");
+
+	printf("\nRemapping Structures...\n\n");
+
+	entry_header = (struct acpi_dmar_entry_header *)(dmar + 1);
+
+	while ( ((unsigned long)entry_header) <
+	   (((unsigned long)dmar) + table->length) ) {
+		switch ( entry_header->type ) {
+		case ACPI_DMAR_DRHD:
+			printf("DMA Remapping Hardware Unit Definition (DRHD) Structure #%d\n", i++);
+			printf("Type:           0x%4.4x (ACPI_DMAR_DRHD)\n", entry_header->type);
+			printf("Length:         0x%4.4x\n", entry_header->length);
+			acpi_parse_one_drhd(entry_header);
+			printf("\n");
+			break;
+		case ACPI_DMAR_RMRR:
+			printf("Reserved Memory Region Reporting (RMRR) Structure #%d\n", j++);
+			printf("Type:           0x%4.4x (ACPI_DMAR_RMRR)\n", entry_header->type);
+			printf("Length:         0x%4.4x\n", entry_header->length);
+			acpi_parse_one_rmrr(entry_header);
+			printf("\n");
+			break;
+		case ACPI_DMAR_ATSR:
+			printf("Root Port ATS Capability Reporting (ATSR) Structure #%d\n", k++);
+			printf("Type:           0x%4.4x (ACPI_DMAR_ATSR)\n", entry_header->type);
+			printf("Length:         0x%4.4x\n", entry_header->length);
+			acpi_parse_one_atsr(entry_header);
+			printf("\n");
+			break;
+		default:
+			printf("Unknown Reporting Structure #%d\n", l++);
+			printf("Type:           0x%4.4x (UNKNOWN)\n", entry_header->type);
+			printf("Length:         0x%4.4x\n", entry_header->length);
+			printf("\n");
+			break;
+		}
+
+		entry_header = ((void *)entry_header + entry_header->length);
+	}
+
+	printf("==================================================\n");
+	printf("End DMAR\n");
+}
+
+void
+usage(void)
+{
+	printf ("Usage: dmardump [input_file]\n");
+	printf ("          [input_file] - binary DMAR table dump\n\n");
+	printf (" If a file is specified, dmardump loads and formats the DMAR table\n");
+	printf (" in the file. If no file is specified, dmardump will read the DMAR table from\n");
+	printf (" the current host's ACPI tables and report it.\n\n");
+}
+
+int
+main(int argc, char *argv[])
+{
+	FILE *infile = NULL;
+	struct stat instat;
+	struct acpi_table_header *table = NULL;
+	size_t rd;
+	int rc;
+
+	if ((argc == 2)&&(strcmp(argv[1], "--help") == 0)) {
+		usage();
+		return 0;
+	}
+
+	if (argc > 1) {
+		if (stat(argv[1], &instat) != 0) {
+			printf("Stat failed for %s\n", argv[1]);
+			return 0;
+		}
+
+		printf("DMAR dump utility - reading input file DMAR: %s size: %d\n", argv[1], (int)instat.st_size);
+
+		table = (struct acpi_table_header *)malloc((size_t)instat.st_size);
+		if (!table) {
+			printf("Allocation failure\n");
+			goto done;
+		}
+
+		infile = fopen(argv[1], "rb");
+		if (!infile) {
+			printf("Could not open %s\n", argv[1]);
+			goto done;
+		}
+
+		rd = fread(table, 1, (size_t)instat.st_size, infile);
+		if (rd != (size_t)instat.st_size) {
+			printf("Failure - only read %d\n", (int)rd);
+			goto done;
+		}
+	} else {
+		printf("DMAR dump utility - reading memory\n");
+
+		table = (struct acpi_table_header *)malloc(DMAR_MAX_BUF);
+		if (!table) {
+			printf("Allocation failure\n");
+			goto done;
+		}
+
+		/* read the local host's ACPI tables */
+		rc = acpi_get_dmar((uint8_t*)table, DMAR_MAX_BUF);
+		if (rc != 0) {
+			printf("Failed to read host DMAR\n");
+			goto done;
+		}
+	}
+
+	acpi_parse_dmar(table);
+
+done:
+	if (table != NULL)
+		free(table);
+	if (infile != NULL)
+		fclose(infile);
+
+	return 0;
+}

--- a/dmardump/utils.c
+++ b/dmardump/utils.c
@@ -1,0 +1,101 @@
+/*
+ * acpi_decode.c: Helper routines to locate and map ACPI tables.
+ *
+ * Copyright (c) 2020, Ross Philipson ross.philipson@gmail.com
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/mman.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include "defs.h"
+
+#define EFI_LINE_SIZE 64
+
+uint8_t *helper_mmap(size_t phys_addr, size_t length)
+{
+	uint32_t page_offset = phys_addr % sysconf(_SC_PAGESIZE);
+	uint8_t *addr;
+	int fd;
+
+	fd = open("/dev/mem", O_RDONLY);
+	if (fd == -1)
+		return NULL;
+
+	addr = (uint8_t*)mmap(0, page_offset + length, PROT_READ, MAP_PRIVATE, fd, phys_addr - page_offset);
+	close(fd);
+
+	if (addr == MAP_FAILED)
+		return NULL;
+
+	return addr + page_offset;
+}
+
+void helper_unmmap(uint8_t *addr, size_t length)
+{
+	uint32_t page_offset = (size_t)addr % sysconf(_SC_PAGESIZE);
+
+	munmap(addr - page_offset, length + page_offset);
+}
+
+int helper_efi_locate(const char *efi_entry, uint32_t length, size_t *location)
+{
+	FILE *systab = NULL;
+	char efiline[EFI_LINE_SIZE];
+	char *val;
+	off_t loc = 0;
+
+	*location = 0;
+
+	/* use EFI tables if present */
+	systab = fopen("/sys/firmware/efi/systab", "r");
+	if (systab == NULL)
+		return -1;
+
+	while((fgets(efiline, EFI_LINE_SIZE - 1, systab)) != NULL) {
+		if (strncmp(efiline, efi_entry, 6) == 0) {
+			/* found EFI entry, get the associated value */
+			val = memchr(efiline, '=', strlen(efiline)) + 1;
+			loc = strtol(val, NULL, 0);
+			break;
+		}
+	}
+	fclose(systab);
+
+	if (loc != 0) {
+		*location = loc;
+		return 0;
+	}
+
+	return -1;
+}


### PR DESCRIPTION
This utility locates and parses the ACPI tables looking for the
DMAR IOMMU reporting table. The table is then decoded and printed
out.

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>